### PR TITLE
Allow to scan more than one kind of bar code at once

### DIFF
--- a/Changelog.rst
+++ b/Changelog.rst
@@ -5,6 +5,7 @@ ChangeLog
 ----------------
 
 - Allow to search for more than one kind of bar code at once
+- **deprecate** scan_codes(str, Image) in favor of scan_codes(list, Image)
 
 
 2.0 (2018-01-24)

--- a/Changelog.rst
+++ b/Changelog.rst
@@ -4,7 +4,7 @@ ChangeLog
 2.1 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Allow to search for more than one kind of bar code at once
 
 
 2.0 (2018-01-24)

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 ZbarLight
 =========
 
-``zbarlight`` is a simple wrapper for the zbar library. For now, it only allows to read QR codes but contributions,
+``zbarlight`` is a simple wrapper for the zbar library. For now, it can read all zbar supported codes. Contributions,
 suggestions and pull requests are welcome.
 
 ``zbarlight`` is compatible with Python 2 and Python 3.

--- a/README.rst
+++ b/README.rst
@@ -49,7 +49,7 @@ How To use ZbarLight
         image = Image.open(image_file)
         image.load()
 
-    codes = zbarlight.scan_codes('qrcode', image)
+    codes = zbarlight.scan_codes(['qrcode'], image)
     print('QR codes: %s' % codes)
 
 Troubleshooting
@@ -70,7 +70,7 @@ alpha channel). You can use the ``copy_image_on_background`` function to add a b
         image.load()
 
     new_image = zbarlight.copy_image_on_background(image, color=zbarlight.WHITE)  # <<<<<<<<<<<<<<<< Add this line <<<<
-    codes = zbarlight.scan_codes('qrcode', new_image)
+    codes = zbarlight.scan_codes(['qrcode'], new_image)
     print('QR codes: %s' % codes)
 
 Some other cases without known solutions are show in the ``scan_codes()`` tests (search for the expected failures). Any

--- a/run.py
+++ b/run.py
@@ -12,8 +12,9 @@ def main():
     with open(args.image, 'rb') as image_file:
         image = Image.open(image_file)
         image.load()
-        codes = zbarlight.scan_codes('qrcode', image)
+        codes = zbarlight.scan_codes(['qrcode'], image)
         print('QR codes: %s' % codes)
+
 
 if __name__ == '__main__':
     main()

--- a/src/zbarlight/__init__.py
+++ b/src/zbarlight/__init__.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
+import warnings
 
 from PIL import Image
 import pkg_resources
@@ -39,14 +40,19 @@ def scan_codes(code_types, image):
     .. [#zbar_symbologies] http://zbar.sourceforge.net/iphone/userguide/symbologies.html
 
     Args:
-        code_types (list or str): Code type(s) to search (see ``zbarlight.Symbologies`` for supported values)
+        code_types (list(str)): Code type(s) to search (see ``zbarlight.Symbologies`` for supported values).
         image (PIL.Image.Image): Image to scan
 
     returns:
         A list of *code_type* code values or None
 
     """
-    code_types = [code_types] if isinstance(code_types, str) else code_types
+    if isinstance(code_types, str):
+        code_types = [code_types]
+        warnings.warn(
+            'Using a str for code_types is deprecated, please use a list of str instead',
+            DeprecationWarning,
+        )
 
     # Translate symbologies
     symbologies = [

--- a/tests/test_scan_codes.py
+++ b/tests/test_scan_codes.py
@@ -1,6 +1,7 @@
 import os.path
 import unittest
 
+import pytest
 from PIL import Image
 
 import zbarlight
@@ -21,17 +22,17 @@ class ScanCodeTestCase(unittest.TestCase):
 
     def test_no_qr_code(self):
         image = self.get_image('no_qr_code')
-        self.assertIsNone(zbarlight.scan_codes('qrcode', image))
+        self.assertIsNone(zbarlight.scan_codes(['qrcode'], image))
 
     def test_one_qr_code(self):
         image = self.get_image('one_qr_code')
-        code = zbarlight.scan_codes('qrcode', image)
+        code = zbarlight.scan_codes(['qrcode'], image)
         self.assertEqual(code, [b"zbarlight test qr code"])
 
     def test_two_qr_code(self):
         image = self.get_image('two_qr_codes')
         self.assertEqual(
-            sorted(zbarlight.scan_codes('qrcode', image)),
+            sorted(zbarlight.scan_codes(['qrcode'], image)),
             sorted([b'second zbarlight test qr code', b'zbarlight test qr code']),
         )
 
@@ -40,13 +41,13 @@ class ScanCodeTestCase(unittest.TestCase):
 
         # Only read QRcode
         self.assertEqual(
-            sorted(zbarlight.scan_codes('qrcode', image)),
+            sorted(zbarlight.scan_codes(['qrcode'], image)),
             sorted([b'zbarlight test qr code']),
         )
 
         # Only read EAN code
         self.assertEqual(
-            sorted(zbarlight.scan_codes('ean13', image)),
+            sorted(zbarlight.scan_codes(['ean13'], image)),
             sorted([b'0012345678905']),
         )
 
@@ -61,7 +62,7 @@ class ScanCodeTestCase(unittest.TestCase):
         image = self.get_image('no_qr_code')
         self.assertRaises(
             zbarlight.UnknownSymbologieError,
-            zbarlight.scan_codes, 'not-a-zbar-symbologie', image,
+            zbarlight.scan_codes, ['not-a-zbar-symbologie'], image,
         )
 
     def test_need_white_background(self):
@@ -70,16 +71,24 @@ class ScanCodeTestCase(unittest.TestCase):
         image = self.get_image('sample_need_white_background')
 
         self.assertEqual(
-            sorted(zbarlight.scan_codes('qrcode', image) or []),
+            sorted(zbarlight.scan_codes(['qrcode'], image) or []),
             [],
         )
 
         # Working when adding white background
         image_with_background = zbarlight.copy_image_on_background(image)
         self.assertEqual(
-            sorted(zbarlight.scan_codes('qrcode', image_with_background) or []),
+            sorted(zbarlight.scan_codes(['qrcode'], image_with_background) or []),
             sorted([b'http://en.m.wikipedia.org']),
         )
+
+    def test_code_type_deprecation(self):
+        image = self.get_image('one_qr_code_and_one_ean')
+        with pytest.deprecated_call():
+            self.assertEqual(
+                sorted(zbarlight.scan_codes('qrcode', image)),
+                sorted([b'zbarlight test qr code']),
+            )
 
     @unittest.expectedFailure
     def test_only_thumbnail_works(self):  # noqa: D200
@@ -90,7 +99,7 @@ class ScanCodeTestCase(unittest.TestCase):
         image = self.get_image('sample_only_thumbnail_works', ext='jpg')
         image.thumbnail((image.size[0] / 8, image.size[1] / 8))
         self.assertEqual(
-            sorted(zbarlight.scan_codes('qrcode', image) or []),
+            sorted(zbarlight.scan_codes(['qrcode'], image) or []),
             sorted([b"It's great! Your app works!"]),
         )
 
@@ -99,13 +108,13 @@ class ScanCodeTestCase(unittest.TestCase):
         bordered = Image.new("RGB", (image.size[0] + 10, image.size[1] + 10), zbarlight.BLACK)
         bordered.paste(image, box=(5, 5))
         self.assertEqual(
-            sorted(zbarlight.scan_codes('qrcode', bordered) or []),
+            sorted(zbarlight.scan_codes(['qrcode'], bordered) or []),
             sorted([b"It's great! Your app works!"]),
         )
 
         # original image
         image = self.get_image('sample_only_thumbnail_works', ext='jpg')
         self.assertEqual(
-            sorted(zbarlight.scan_codes('qrcode', image) or []),
+            sorted(zbarlight.scan_codes(['qrcode'], image) or []),
             sorted([b"It's great! Your app works!"]),
         )

--- a/tests/test_scan_codes.py
+++ b/tests/test_scan_codes.py
@@ -50,6 +50,13 @@ class ScanCodeTestCase(unittest.TestCase):
             sorted([b'0012345678905']),
         )
 
+    def test_one_qr_code_and_one_ean_at_once(self):
+        image = self.get_image('one_qr_code_and_one_ean')
+        self.assertEqual(
+            sorted(zbarlight.scan_codes(['qrcode', 'ean13'], image)),
+            sorted([b'zbarlight test qr code', b'0012345678905']),
+        )
+
     def test_unknown_symbology(self):
         image = self.get_image('no_qr_code')
         self.assertRaises(


### PR DESCRIPTION
As suggested by @AndreMiras, zbarlight should be able to scan more than
one code type at once.

Linked to #23