### PR TITLE
Drop useless zbar version getter in C module

### DIFF
--- a/Changelog.rst
+++ b/Changelog.rst
@@ -4,7 +4,7 @@ ChangeLog
 2.3 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Support https://github.com/mchehab/zbar zbar fork (used by ArchLinux)
 
 
 2.2 (2019-01-21)

--- a/src/zbarlight/_zbarlight.c
+++ b/src/zbarlight/_zbarlight.c
@@ -100,21 +100,8 @@ static PyObject* zbar_code_scanner(PyObject *self, PyObject *args) {
     return data;
 }
 
-/* Get zbar version */
-static PyObject* version(PyObject *self, PyObject *args) {
-    unsigned int major, minor;
-
-    if (!PyArg_ParseTuple(args, "")) {
-        return NULL;
-    }
-
-    zbar_version(&major, &minor);
-    return Py_BuildValue("II", major, minor);
-}
-
 /* Module initialization */
 static PyMethodDef zbarlight_functions[] = {
-    { "version", version, METH_VARARGS, NULL},
     { "zbar_code_scanner", zbar_code_scanner, METH_VARARGS, NULL},
     { NULL }
 };


### PR DESCRIPTION
This will allow to use zbar >= 0.20.1 (see
https://github.com/mchehab/zbar).