### PR TITLE
Update Python supported versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,9 @@
 language: python
+dist: xenial
 python:
-  - "2.7"
   - "3.5"
   - "3.6"
-matrix:
-  include:
-    - python: 3.7
-      dist: xenial
+  - "3.7"
 addons:
   apt:
     packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
   - "3.5"
   - "3.6"
   - "3.7"
+  - "3.8"
 addons:
   apt:
     packages:

--- a/Changelog.rst
+++ b/Changelog.rst
@@ -4,7 +4,8 @@ ChangeLog
 2.4 (unreleased)
 ----------------
 
-- Drop Python 3.4 support
+- Drop Python 2.7 support (end-of-life 2020-01-01) **breaking change**
+- Drop Python 3.4 support (end-of-life 2019-03-18) **breaking change**
 
 
 2.3 (2019-03-21)

--- a/Changelog.rst
+++ b/Changelog.rst
@@ -4,6 +4,7 @@ ChangeLog
 2.4 (unreleased)
 ----------------
 
+- Add Python 3.8 support
 - Drop Python 2.7 support (end-of-life 2020-01-01) **breaking change**
 - Drop Python 3.4 support (end-of-life 2019-03-18) **breaking change**
 

--- a/README.rst
+++ b/README.rst
@@ -4,8 +4,6 @@ ZbarLight
 ``zbarlight`` is a simple wrapper for the zbar library. For now, it can read all zbar supported codes. Contributions,
 suggestions and pull requests are welcome.
 
-``zbarlight`` is compatible with Python 2 and Python 3.
-
 ``zbarlight`` is hosted on Github at <https://github.com/Polyconseil/zbarlight/>.
 
 Installation

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,6 +18,7 @@ classifiers =
     Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
     Topic :: Scientific/Engineering :: Image Recognition
 
 [options]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = zbarlight
-version = 2.4.dev0
+version = 3.dev0
 author = Polyconseil
 author_email = opensource+zbarlight@polyconseil.fr
 url = https://github.com/Polyconseil/zbarlight
@@ -15,8 +15,6 @@ classifiers =
     Natural Language :: English
     Operating System :: OS Independent
     Programming Language :: C
-    Programming Language :: Python :: 2.7
-    Programming Language :: Python :: 3.4
     Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
@@ -26,6 +24,7 @@ classifiers =
 zip_safe = False
 include_package_data = True
 packages = find:
+python_requires = >= 3
 setup_requires =
     setuptools
 install_requires =

--- a/src/zbarlight/__init__.py
+++ b/src/zbarlight/__init__.py
@@ -1,6 +1,3 @@
-from __future__ import absolute_import
-from __future__ import unicode_literals
-
 import warnings
 
 import pkg_resources

--- a/src/zbarlight/_zbarlight.c
+++ b/src/zbarlight/_zbarlight.c
@@ -2,15 +2,6 @@
 #include <stdlib.h>
 #include <zbar.h>
 
-/* Python 2 and Python 3 Compatibility */
-#if PY_MAJOR_VERSION >= 3
-#define PY_BYTES_FROM_STRING(result) PyBytes_FromString(result)
-#define PY_INIT_FCT() PyModule_Create(&zbarlight_moduledef)
-#else
-#define PY_BYTES_FROM_STRING(result) PyString_FromString(result)
-#define PY_INIT_FCT() Py_InitModule("_zbarlight", zbarlight_functions)
-#endif
-
 #define KNOWN_SYMNOLOGIES 15
 
 struct Symbologies {
@@ -92,7 +83,7 @@ static PyObject* zbar_code_scanner(PyObject *self, PyObject *args) {
 
     data = PyList_New(0);
     for(int i=0; result[i] != NULL; i++) {
-        PyObject *item = PY_BYTES_FROM_STRING(result[i]);
+        PyObject *item = PyBytes_FromString(result[i]);
         PyList_Append(data, item);
         free(result[i]);
     }
@@ -106,7 +97,6 @@ static PyMethodDef zbarlight_functions[] = {
     { NULL }
 };
 
-#if PY_MAJOR_VERSION >= 3
 static struct PyModuleDef zbarlight_moduledef = {
     PyModuleDef_HEAD_INIT,
     "_zbarlight",
@@ -114,10 +104,9 @@ static struct PyModuleDef zbarlight_moduledef = {
     -1,
     zbarlight_functions,
 };
-#endif
 
-PyObject* PyInit__zbarlight(void) { /* Python 3 way */
-    PyObject* module = PY_INIT_FCT();
+PyObject* PyInit__zbarlight(void) {
+    PyObject* module = PyModule_Create(&zbarlight_moduledef);
     PyObject * symbologies = Py_BuildValue(
         /* XXX: Do not forget to update KNOWN_SYMNOLOGIES when updating this */
         #if ZBAR_VERSION_MAJOR == 0 && ZBAR_VERSION_MINOR < 11
@@ -143,8 +132,4 @@ PyObject* PyInit__zbarlight(void) { /* Python 3 way */
     );
     PyModule_AddObject(module, "Symbologies", symbologies);
     return module;
-}
-
-void init_zbarlight(void) { /* Python 2 way */
-    PyInit__zbarlight();
 }

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py35, py36, py37, docs, quality
+envlist = py35, py36, py37, py38, docs, quality
 skip_missing_interpreters = True
 
 [testenv:docs]
@@ -15,5 +15,5 @@ deps = pytest
 whitelist_externals = make
 commands = make tests
 
-[tox:travis]
-3.7 = py37, docs, quality
+[travis]
+3.8 = py38, docs, quality

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py35, py36, py37, docs, quality
+envlist = py35, py36, py37, docs, quality
 skip_missing_interpreters = True
 
 [testenv:docs]


### PR DESCRIPTION
# Description

- Drop Python 2.7 support as end-of-life is in less than 9 days (2020-01-01)
- Add Python 3.8 support