### PR TITLE
build: Move build config to `pyproject.toml`

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,6 +4,8 @@ build:
   os: ubuntu-24.04
   tools:
     python: "3.14"
+  apt_packages:
+    - libzbar-dev
 
 sphinx:
   configuration: docs/conf.py

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,30 +1,4 @@
 import importlib.metadata
-import os
-import sys
-
-
-class _Zbarlight(object):
-    """
-    Fake zbarlight C extension
-
-    Should be updated when C extension change.
-    """
-
-    def zbar_code_scanner(self, *args):
-        pass
-
-    def version(self):
-        pass
-
-    @classmethod
-    def monkey_patch(cls):
-        """Monkey path zbarlight C extension on Read The Docs"""
-        on_read_the_docs = os.environ.get("READTHEDOCS", False)
-        if on_read_the_docs:
-            sys.modules["zbarlight._zbarlight"] = cls
-
-
-_Zbarlight.monkey_patch()
 
 project = "zbarlight"
 copyright = "2014, Polyconseil"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,3 +92,10 @@ disable = [
     "unused-argument",
     "wrong-import-order",
 ]
+
+
+[[tool.setuptools.ext-modules]]
+name = "zbarlight._zbarlight"
+sources = ["src/zbarlight/_zbarlight.c"]
+extra-compile-args = ["-std=c99"]
+libraries= ["zbar"]

--- a/setup.py
+++ b/setup.py
@@ -1,22 +1,4 @@
 #!/usr/bin/env python
-import os
-
-from setuptools import Extension
 from setuptools import setup
 
-setup(
-    package_dir={  # FIXME: wait for https://github.com/pypa/setuptools/issues/1136
-        "": "src",
-    },
-    ext_modules=[
-        Extension(
-            name=str("zbarlight._zbarlight"),
-            sources=[str("src/zbarlight/_zbarlight.c")],
-            extra_compile_args=["-std=c99"],
-            libraries=["zbar"],
-            optional=os.environ.get(
-                "READTHEDOCS", False
-            ),  # Do not build on Read the Docs
-        ),
-    ],
-)
+setup()


### PR DESCRIPTION
We can build the C extension on ReadTheDocs, so we can get rid of the
`optional` argument in `Extension()` in `setup.py`. The rest of the
build config can be moved to `pyproject.toml`.

A warning appears when building:

    .../setuptools/config/pyprojecttoml.py:72: _ExperimentalConfiguration: `[tool.setuptools.ext-modules]` in `pyproject.toml` is still *experimental* and likely to change in future releases.

... but it's the only difference. So let's be adventurous and put
everything in `pyproject.toml`! :)